### PR TITLE
feat: react-router-domを導入し、App.jsxに基本ルーティングを実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -1628,6 +1629,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2502,6 +2512,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.5.tgz",
+      "integrity": "sha512-JmxqrnBZ6E9hWmf02jzNn9Jm3UqyeimyiwzD69NjxGySG6lIz/1LVPsoTCwN7NBX2XjCEa1LIX5EMz1j2b6u6A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.5.tgz",
+      "integrity": "sha512-mkEmq/K8tKN63Ae2M7Xgz3c9l9YNbY+NHH6NNeUmLA3kDkhKXRsNb/ZpxaEunvGo2/3YXdk5EJU3Hxp3ocaBPw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2569,6 +2617,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,21 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import SetupPage from "./pages/SetupPage";
+import PlayPage from "./pages/PlayPage";
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <BrowserRouter>
+      <nav className="flex justify-center gap-4 p-4 bg-gray-800 text-white">
+        <Link to="/">Setup</Link>
+        <Link to="/play">Play</Link>
+      </nav>
+
+      <Routes>
+        <Route path="/" element={<SetupPage />} />
+        <Route path="/play" element={<PlayPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
-export default App
+export default App;

--- a/src/pages/PlayPage.jsx
+++ b/src/pages/PlayPage.jsx
@@ -1,0 +1,9 @@
+// src/pages/PlayPage.jsx
+export default function PlayPage() {
+  return (
+    <div className="text-center mt-10">
+      <h1 className="text-2xl font-bold">進行ページ</h1>
+      <p>ここにタイマーなどを追加していきます。</p>
+    </div>
+  );
+}

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -1,0 +1,9 @@
+// src/pages/SetupPage.jsx
+export default function SetupPage() {
+  return (
+    <div className="text-center mt-10">
+      <h1 className="text-2xl font-bold">トーナメント設定ページ</h1>
+      <p>ここにレベル設定UIを追加していきます。</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Pull Request: M2-1 — ルーティング機能の導入（Setup / Play ページ）
■ 概要

このPRでは、Poker Tournament Timer アプリにおける 基本的なルーティング機能 を実装しました。
react-router-dom を導入し、Setup ページおよび Play ページ間の遷移を可能にしています。
これにより、今後の機能実装に向けたアプリ全体のページ構成の基盤が整いました。

■ 追加内容

react-router-dom の導入

src/pages/ ディレクトリを新規作成し、Setup.jsx と Play.jsx を追加

App.jsx にルーティング設定を実装

/setup → トーナメント設定画面（Setup ページ）

/play → トーナメント実行画面（Play ページ）

簡易的なナビゲーションバー（<Link>）を追加

■ 動作確認

依存関係をインストール

npm install


開発サーバー起動

npm run dev


ブラウザで以下を確認

http://localhost:5173/ → Setup ページが表示される

ナビゲーションリンクから /play に遷移可能

関連Issue：https://github.com/Nico226213/poker_tornament_application/issues/2