### PR TITLE
トーナメント設定入力と進行画面レイアウトの作成

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,12 +6,14 @@ function App() {
   return (
     <BrowserRouter>
       <nav className="flex justify-center gap-4 p-4 bg-gray-800 text-white">
-        <Link to="/">Setup</Link>
+        <Link to="/setup">Setup</Link>
         <Link to="/play">Play</Link>
       </nav>
 
       <Routes>
+        {/* 初期ページをSetupPageにしておく */}
         <Route path="/" element={<SetupPage />} />
+        <Route path="/setup" element={<SetupPage />} />
         <Route path="/play" element={<PlayPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/PlayPage.jsx
+++ b/src/pages/PlayPage.jsx
@@ -1,9 +1,39 @@
-// src/pages/PlayPage.jsx
-export default function PlayPage() {
+// src/pages/Play.jsx
+import React from "react";
+
+function Play() {
+  const mockData = {
+    level: 1,
+    smallBlind: 100,
+    bigBlind: 200,
+    ante: 0,
+    remainingTime: "30:00",
+  };
+
   return (
-    <div className="text-center mt-10">
-      <h1 className="text-2xl font-bold">進行ページ</h1>
-      <p>ここにタイマーなどを追加していきます。</p>
+    <div className="min-h-screen bg-gray-900 text-white flex flex-col items-center justify-center p-8">
+      <h1 className="text-3xl font-bold mb-8">トーナメント進行</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-4xl">
+        <div className="bg-gray-800 p-6 rounded-2xl text-center shadow-lg">
+          <h2 className="text-lg font-semibold mb-2">Level</h2>
+          <p className="text-2xl">{mockData.level}</p>
+        </div>
+
+        <div className="bg-gray-800 p-6 rounded-2xl text-center shadow-lg">
+          <h2 className="text-lg font-semibold mb-2">Blinds</h2>
+          <p className="text-2xl">
+            {mockData.smallBlind} / {mockData.bigBlind}
+          </p>
+        </div>
+
+        <div className="bg-gray-800 p-6 rounded-2xl text-center shadow-lg">
+          <h2 className="text-lg font-semibold mb-2">Time</h2>
+          <p className="text-2xl">{mockData.remainingTime}</p>
+        </div>
+      </div>
     </div>
   );
 }
+
+export default Play;

--- a/src/pages/SetupPage.jsx
+++ b/src/pages/SetupPage.jsx
@@ -1,9 +1,88 @@
-// src/pages/SetupPage.jsx
-export default function SetupPage() {
+import { useState } from "react";
+
+function Setup() {
+  const [tournamentName, setTournamentName] = useState("");
+  const [playerCount, setPlayerCount] = useState(8);
+  const [startChips, setStartChips] = useState(10000);
+  const [blindInterval, setBlindInterval] = useState(15);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log("設定内容:", {
+      tournamentName,
+      playerCount,
+      startChips,
+      blindInterval,
+    });
+  };
+
   return (
-    <div className="text-center mt-10">
-      <h1 className="text-2xl font-bold">トーナメント設定ページ</h1>
-      <p>ここにレベル設定UIを追加していきます。</p>
+    <div className="flex justify-center items-center min-h-screen bg-gray-100">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white shadow-md rounded-2xl p-8 w-full max-w-md"
+      >
+        <h2 className="text-2xl font-bold mb-6 text-center">
+          トーナメント設定
+        </h2>
+
+        <div className="mb-4">
+          <label className="block text-gray-700 mb-2">トーナメント名</label>
+          <input
+            type="text"
+            value={tournamentName}
+            onChange={(e) => setTournamentName(e.target.value)}
+            className="w-full border rounded px-3 py-2 focus:outline-none focus:ring focus:ring-blue-300"
+            placeholder="例: Monthly Poker Cup"
+          />
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-gray-700 mb-2">プレイヤー数</label>
+          <input
+            type="number"
+            min="2"
+            value={playerCount}
+            onChange={(e) => setPlayerCount(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-gray-700 mb-2">スタートチップ</label>
+          <input
+            type="number"
+            min="1000"
+            step="1000"
+            value={startChips}
+            onChange={(e) => setStartChips(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+        </div>
+
+        <div className="mb-6">
+          <label className="block text-gray-700 mb-2">
+            ブラインド間隔（分）
+          </label>
+          <input
+            type="number"
+            min="5"
+            step="5"
+            value={blindInterval}
+            onChange={(e) => setBlindInterval(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600 transition"
+        >
+          登録
+        </button>
+      </form>
     </div>
   );
 }
+
+export default Setup;


### PR DESCRIPTION
・概要

このPRでは、トーナメント設定画面（Setupページ）と進行画面（Playページ）の基本構造を実装しました。
設定画面では、入力フォームからトーナメント情報を取得し、現時点ではコンソールに出力することでデータ受け渡しの流れを確認しています。
進行画面では、仮データを使ってレベル・ブラインド・残り時間などを表示するレイアウトを作成しました。

・追加内容

Setupページ

トーナメント設定フォームを実装

入力内容をコンソールに出力（データ送信動作の確認）

Playページ

仮データをもとにブラインドレベル情報などを表示

TailwindCSSを用いて仮レイアウトを構築（今後カード化予定）

ルーティング調整

/setup および /play ページ間を react-router-dom で遷移可能に設定

。動作確認

/setup にアクセスし、フォームに値を入力

「送信」押下で、入力内容がブラウザのコンソールに表示されることを確認

/play にアクセスすると、仮データのトーナメント情報が整列して表示されることを確認


関連Issue：https://github.com/Nico226213/poker_tornament_application/issues/3